### PR TITLE
Update Ticker endpoint to reflect current API return (removed Symbol)

### DIFF
--- a/bitfinex/rest/restv2.py
+++ b/bitfinex/rest/restv2.py
@@ -262,7 +262,6 @@ class Client:
 
                 # on trading pairs (ex. tBTCUSD)
                 [
-                  SYMBOL,
                   BID,
                   BID_SIZE,
                   ASK,
@@ -276,7 +275,6 @@ class Client:
                 ]
                 # on funding currencies (ex. fUSD)
                 [
-                  SYMBOL,
                   FRR,
                   BID,
                   BID_SIZE,


### PR DESCRIPTION
[The current V2 API](https://docs.bitfinex.com/v2/reference#rest-public-ticker) does not have the Symbol in the `ticker` endpoint. I removed it from the docstring (and subsequently the docs).